### PR TITLE
Move Summary on 57x32mm tickets

### DIFF
--- a/class/genpdf.class.php
+++ b/class/genpdf.class.php
@@ -34,22 +34,21 @@ class Genpdf {
     $pdf = new FPDF();
     $pdf->AddPage('L',array(57,32));
 
-    $pdf->SetFont('Times','B');
     $pdf->SetFontSize('8.5');
-    $pdf->Text('1','4','Catalog #:' . $record->catalog_id);
-    $pdf->Text('33','4','Site:'. $record->site->name);
-    $pdf->Text('1','8','Proj:' . $record->site->project);
-    $pdf->Text('33','8','Acc#:' . $record->accession);
-    $pdf->Text('1','12','Date:'.date('m/d/Y',$record->created));
-    $pdf->Text('33','12','Unit:'. $record->level->unit);
-    $pdf->Text('1','16','Name:' . $record->user->name); 
-    $pdf->Text('33','16','Level:'. $record->level->catalog_id);
-    $pdf->Text('1','20','Item(s):' . $record->material->name);
-    $pdf->Text('33','20','N = '. $record->quanity);
-    $pdf->Text('3','23',' ('. $record->classification->name . ')');
-    $pdf->Text('1','27','MASL:' . $masl);
     $pdf->SetFont('Times','B');
-    $pdf->Text('9','31',$record->accession . ' - ' . $site_abv . ' - ' . $record->level->unit . '/' . $record->level->quad->name . ' - ' . $record->level->catalog_id . ' - ' . $record->catalog_id);
+    $pdf->Text('9','4',$record->accession . ' - ' . $site_abv . ' - ' . $record->level->unit . '/' . $record->level->quad->name . ' - ' . $record->level->catalog_id . ' - ' . $record->catalog_id);
+    $pdf->Text('1','8','Catalog #:' . $record->catalog_id);
+    $pdf->Text('33','8','Site:'. $record->site->name);
+    $pdf->Text('1','12','Proj:' . $record->site->project);
+    $pdf->Text('33','12','Acc#:' . $record->accession);
+    $pdf->Text('1','16','Date:'.date('m/d/Y',$record->created));
+    $pdf->Text('33','16','Unit:'. $record->level->unit);
+    $pdf->Text('1','20','Name:' . $record->user->name); 
+    $pdf->Text('33','20','Level:'. $record->level->catalog_id);
+    $pdf->Text('1','23','Item(s):' . $record->material->name);
+    $pdf->Text('33','23','N = '. $record->quanity);
+    $pdf->Text('3','27',' ('. $record->classification->name . ')');
+    $pdf->Text('1','31','MASL:' . $masl);
   
 
     $pdf->Output($filename);

--- a/config/settings.php.dist
+++ b/config/settings.php.dist
@@ -16,7 +16,7 @@ ticket_size=88x25mm
 log_path=/var/log/archie
 
 ; This is the root of the attached/fs data
-data_root=/var/www/content
+data_root=/var/lib/archie
 
 ; Operational stuff
 ;; This is the number of records per page


### PR DESCRIPTION
CHANGE - Per UofO request move the summary line to the top on the 57x32mm tickets. Also change the default data path in config/settings.php.dist 